### PR TITLE
Configureable XDebug via 2 new env vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ The variants of this image are:
 
 Environment variables
 ------------------
-1. XDEBUG_ENABLE: Adds xdebug extension which is configured to autostart (assumes Docker for Mac).
+1. XDEBUG_ENABLE: Adds xdebug extension which is configured to autostart.
 2. MEMORY_LIMIT: Set the PHP memory limit that is used.
+3. XDEBUG_REMOTE_HOST: Defaults to `host.docker.internal` (good for OSX). If using Linux, see https://github.com/docker/for-linux/issues/264
+4. XDEBUG_IDEKEY: Defaults to `PHPSTORM`.
 
 Making changes
 --------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Environment variables
 ------------------
 1. XDEBUG_ENABLE: Adds xdebug extension which is configured to autostart.
 2. MEMORY_LIMIT: Set the PHP memory limit that is used.
-3. XDEBUG_REMOTE_HOST: Defaults to `host.docker.internal` (good for OSX). If using Linux, see https://github.com/docker/for-linux/issues/264
+3. XDEBUG_REMOTE_HOST: Defaults to `host.docker.internal` (good for OSX). If using Linux, see https://github.com/docker/for-linux/issues/264 and https://biancatamayo.me/blog/2017/11/03/docker-add-host-ip/
 4. XDEBUG_IDEKEY: Defaults to `PHPSTORM`.
 
 Making changes

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -123,7 +123,7 @@ RUN curl -OL https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhse
 
 
 # Install development tools.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.6.1 \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.remote_enable=on\nxdebug.remote_autostart=on" > $PHP_INI_DIR/conf.d/xdebug.ini \
   # Install Blackfire Probe

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -8,6 +8,8 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV SENDMAIL_PATH /bin/true
 ENV MEMORY_LIMIT 256m
+ENV XDEBUG_REMOTE_HOST=host.docker.internal
+ENV XDEBUG_IDEKEY=PHPSTORM
 ENV PATH=/var/www/mass.local/vendor/bin:$PATH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -123,7 +125,7 @@ RUN curl -OL https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhse
 # Install development tools.
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.remote_enable=on\nxdebug.remote_host=docker.for.mac.host.internal\nxdebug.remote_autostart=on\nxdebug.idekey=PHPSTORM" > $PHP_INI_DIR/conf.d/xdebug.ini \
+  && echo "xdebug.remote_enable=on\nxdebug.remote_autostart=on" > $PHP_INI_DIR/conf.d/xdebug.ini \
   # Install Blackfire Probe
   && version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
   && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \

--- a/dev/etc/php-overrides.ini
+++ b/dev/etc/php-overrides.ini
@@ -5,6 +5,8 @@
 upload_max_filesize = 128M
 post_max_size = 128M
 memory_limit = ${MEMORY_LIMIT}
+xdebug.remote_host=${XDEBUG_REMOTE_HOST}
+xdebug.idekey=${XDEBUG_IDEKEY}
 sendmail_path = ${SENDMAIL_PATH}
 date.timezone = UTC
 


### PR DESCRIPTION
I setup a Chromebook with Docker and VS Code and its working surprisingly well.

Our XDebug assumes Docker for Mac so lets fix that.