### PR TITLE
Update extension name to remove “.so”

### DIFF
--- a/dev/bin/apache2-foreground-enhanced
+++ b/dev/bin/apache2-foreground-enhanced
@@ -16,11 +16,11 @@ fi
 
 # Enable Xdebug by setting XDEBUG_ENABLE=1.
 if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
-  # Comment out .so include.
-  sed -i 's/^\(zend_extension=.*xdebug\.so\)$/; \1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+  # Comment out the extension include.
+  sed -i 's/^\(zend_extension=.*xdebug\)$/; \1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
 else
   # Uncomment
-  sed -i 's/^; \(zend_extension=.*xdebug\.so\)$/\1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+  sed -i 's/^; \(zend_extension=.*xdebug\)$/\1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
 fi
 
 exec apache2-foreground


### PR DESCRIPTION
it turns out the sed regex no longer works because the xdebug doesn't have ".so" on the end.